### PR TITLE
Feat/bug-report-and-feature-request-templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -55,12 +55,13 @@ body:
   - type: textarea
     id: logs
     attributes:
-      label: Relevant log output
+      label: "Optional: Relevant log output"
       description: | 
         Please copy and paste any relevant log output. This will be automatically 
         formatted into code, so no need for backticks.
       render: shell
-  - type: textarea 
+    validations:
+      required: false
     id: severity-priority
     attribute: 
       label: Severity/Priority 

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -80,7 +80,7 @@ body:
     attributes:
       label: Contact Details
       description: How can we get in touch with you if we need more info?
-      placeholder: ex. email@example.com
+      placeholder: email@example.com
     validations:
       required: false
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -62,6 +62,7 @@ body:
       render: shell
     validations:
       required: false
+  - type: dropdown 
     id: severity-priority
     attribute: 
       label: Severity/Priority 
@@ -70,6 +71,10 @@ body:
         1: High/Critical: anything that impacts the user flow or blocks usage
         2: Medium: anything that negatively affects the user experience 
         3: Minor: everything else (e.g., typos, missing icons, layout issues, etc.)
+      options: 
+        - 1: High/Critical
+        - 2: Medium
+        - 3: Minor
   - type: input
     id: contact
     attributes:

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -18,8 +18,6 @@ body:
   #     default: 0
   #   validations:
   #     required: true
-    validations:
-      required: true
   - type: textarea
     id: steps-to-reproduce
     attributes: 
@@ -52,6 +50,8 @@ body:
         What actually happened, when you did the steps above? Be as 
         specific as you can when describing this. 
         If possible, include screenshots or videos here as well.
+    validations:
+      required: true
   - type: textarea
     id: logs
     attributes:

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -1,0 +1,87 @@
+name: Bug Report
+description: File a bug report
+title: "[bug]: <title>"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  # - type: dropdown -- include this when we start versioning
+  #   id: version
+  #   attributes:
+  #     label: Version
+  #     description: What version of our software are you running?
+  #     options:
+  #       - 1.0.2 (Default)
+  #       - 1.0.3 (Edge)
+  #     default: 0
+  #   validations:
+  #     required: true
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes: 
+      label: Steps to reproduce
+      description: | 
+        How do you trigger this bug? Please walk us through it step by step.
+        Use the “>” symbol to show the steps. 
+        Example: 
+        1. Go to settings > Profile (this would take user to new screen)
+        2. Tap on More Options > Delete Account 
+      value: |
+        1.
+        2.
+        3.
+        ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected-result
+    attributes: 
+      label: Expected result
+      description: What should happen, when you do the steps above? 
+    validations: 
+      required: true
+  - type: textarea
+    id: actual-result
+    attributes: 
+      label: Actual result (the bug)
+      description: | 
+        What actually happened, when you did the steps above? Be as 
+        specific as you can when describing this. 
+        If possible, include screenshots or videos here as well.
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: | 
+        Please copy and paste any relevant log output. This will be automatically 
+        formatted into code, so no need for backticks.
+      render: shell
+  - type: textarea 
+    id: severity-priority
+    attribute: 
+      label: Severity/Priority 
+      description: | 
+        Describe the severity of the impact the bug has on the software's functionality
+        1: High/Critical: anything that impacts the user flow or blocks usage
+        2: Medium: anything that negatively affects the user experience 
+        3: Minor: everything else (e.g., typos, missing icons, layout issues, etc.)
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](../CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
@@ -1,0 +1,40 @@
+name: Feature Request
+description: Request a new or improved feature
+title: "[feature-request]: <title>"
+labels: ["feature-request"]
+body: 
+  - type: markdown
+    attributes: 
+      value: | 
+        Thanks for taking the time to fill out this feature request. 
+        Please search in existing issues first to ensure this feature has not already 
+        been requested.
+  - type: textarea
+    id: feature-request
+    attributes: 
+      label: What feature would you like to request? 
+      description: |
+        Please present a concise description of the problem to be addressed by this 
+        feature request, and be as clear as you can on what parts of the problem that 
+        are considered to be in-scope and out-of-scope.
+    validations: 
+      required: true
+  - type: textarea
+    id: solution
+    attributes: 
+      label: "(Optional): Suggest A Solution"
+      description: | 
+        A concise description of your preferred solution. Things to address include:
+        * Details of the technical implementation
+        * Tradeoffs made in design decisions
+        * Caveats and considerations for the future
+    validations: 
+      required: false
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](../CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
@@ -22,7 +22,7 @@ body:
   - type: textarea
     id: solution
     attributes: 
-      label: "(Optional): Suggest A Solution"
+      label: "Optional: Suggest A Solution"
       description: | 
         A concise description of your preferred solution. Things to address include:
         * Details of the technical implementation


### PR DESCRIPTION
I have created two additional issue templates (aside from the user story template in #2): 
- A bug report template (inspired by [this post](https://testlio.com/blog/the-ideal-bug-report/) and GitHub Docs)
- A feature request template (inspired by [eslint](https://github.com/eslint/eslint/blob/main/.github/ISSUE_TEMPLATE/change.yml) and GitHub Docs)

What do you think? :-) 

(PS I can't figure out how to preview these issue templates locally, so there might be some bugs that I'm only able to see once we have merged into main)