### PR TITLE
feat: 13 bug incorrect link to code of conduct in issue templates all three

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -72,9 +72,9 @@ body:
         2: Medium: anything that negatively affects the user experience 
         3: Minor: everything else (e.g., typos, missing icons, layout issues, etc.)
       options: 
-        - 1: High/Critical
-        - 2: Medium
-        - 3: Minor
+        - "1: High/Critical"
+        - "2: Medium"
+        - "3: Minor"
   - type: input
     id: contact
     attributes:

--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -87,7 +87,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](../CODE_OF_CONDUCT.md)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](../../CODE_OF_CONDUCT.md).
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
@@ -37,7 +37,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](../CODE_OF_CONDUCT.md).
+      description: By submitting this issue, you agree to follow our [Code of Conduct](../../CODE_OF_CONDUCT.md).
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/USER-STORY.yml
+++ b/.github/ISSUE_TEMPLATE/USER-STORY.yml
@@ -24,7 +24,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](../CODE_OF_CONDUCT.md).
+      description: By submitting this issue, you agree to follow our [Code of Conduct](../../CODE_OF_CONDUCT.md).
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/USER-STORY.yml
+++ b/.github/ISSUE_TEMPLATE/USER-STORY.yml
@@ -1,4 +1,4 @@
-name: User story
+name: User Story
 description: Create a user story
 title: "[user-story]: <title>"
 labels: ["user-story"]


### PR DESCRIPTION
- Fix link to Code of Conduct in issue templates 
- Capitalise 's' in user story to fit the other issue templates
- Put quotation around options in dropdown (hoping it will fix layout issues - options were shown in curly brackets, see below)

<img width="173" alt="Screenshot 2023-11-14 at 13 30 29" src="https://github.com/seedcase-project/.github/assets/40836345/9de7261b-5373-414e-8d74-6aafad577321">
