### PR TITLE
feat: add auto author assign action

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -13,5 +13,3 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: toshimaru/auto-author-assign@v2.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -1,0 +1,17 @@
+# .github/workflows/auto-author-assign.yml
+name: Auto Author Assign
+
+on:
+  pull_request_target:
+    types: [ opened, reopened ]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v2.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Action that automatically assigns author to pr when its opened or reopened. 

If we want to, we could do the same for issues by adding the following lines:
```
on:
  issues:
    types: [ opened, reopened ]
  pull_request_target:
    types: [ opened, reopened ]

permissions:
  issues: write
  pull-requests: write
```

Action copied from: https://github.com/marketplace/actions/auto-author-assign

Note: I did edit L17 from `repo-token: ${{ secrets.YOUR_TOKEN }}` to `repo-token: ${{ secrets.GITHUB_TOKEN }}` (based on the action from the [AdvancedR course](https://r-cubed-advanced.rostools.org/sessions/build-website#automate-rendering-the-website) since VS Code gave me a warning about YOUR_TOKEN)