### PR TITLE
Update CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,10 @@
-# All team members get added to review PRs
-* @K-Beicher @lwjohnst86 @signekb
+# All members on Developers team get added to review PRs
+* @seedcase-project/developers
+
+# Ignore these so we don't get added to sync PRs
+/.github/
+/.vscode/
+/.devcontainer/
+justfile
+.editorconfig
+.gitignore

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # All team members get added to review PRs
-* @K-Beicher @lwjohnst86 @rqding @signekb
+* @K-Beicher @lwjohnst86 @signekb


### PR DESCRIPTION
Ignore the settings files and use team name instead of individual person names.

Closes #25