### PR TITLE
fix: remove pre-commit hooks from checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull-request-code.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull-request-code.md
@@ -54,5 +54,4 @@ Closes Issue ...
 - [ ] Tests accompany or reflect changes to the code
 - [ ] Tests ran and passed locally
 - [ ] Ran the linter and formatter
-- [ ] Build and pre-commit hooks have passed locally
 - [ ] Relevant documentation has been updated

--- a/.github/PULL_REQUEST_TEMPLATE/pull-request-code.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull-request-code.md
@@ -54,4 +54,5 @@ Closes Issue ...
 - [ ] Tests accompany or reflect changes to the code
 - [ ] Tests ran and passed locally
 - [ ] Ran the linter and formatter
+- [ ] Build has passed locally
 - [ ] Relevant documentation has been updated

--- a/.github/PULL_REQUEST_TEMPLATE/pull-request-documentation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull-request-documentation.md
@@ -25,6 +25,5 @@ Closes Issue ...
 - [ ] Spell-check
     - [ ] US
     - [ ] UK
-- [ ] Pre-commit hooks have passed locally without warnings or errors
 - [ ] Did the page(s) preview correctly on your machine without breaking
 - [ ] New category words (keywords) (if any) added to the code snippet file


### PR DESCRIPTION
we will not implement pre-commit hooks after all