### PR TITLE
feat: add ruff

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -16,7 +16,8 @@
 		"njpwerner.autodocstring",
 		"quarto.quarto",
 		"streetsidesoftware.code-spell-checker",
-		"vivaxy.vscode-conventional-commits"
+		"vivaxy.vscode-conventional-commits",
+		"charliermarsh.ruff"
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": [

--- a/common/justfile/docker-dev
+++ b/common/justfile/docker-dev
@@ -31,10 +31,10 @@ resume-docker:
 update-migrations:
   python manage.py makemigrations
 
-# Lint using Ruff - requires ruff-lsp to be installed
+# Run Python linter to check for any errors in the code
 lint-python:
   poetry run ruff check --fix .
 
-# Format using Ruff - requires ruff-lsp to be installed
+# Reformat Python code to match coding style and general structure
 format-python:
   poetry run ruff format .

--- a/common/justfile/docker-dev
+++ b/common/justfile/docker-dev
@@ -33,8 +33,8 @@ update-migrations:
 
 # Lint using Ruff - requires ruff-lsp to be installed
 lint-python:
-  ruff check --fix .
+  poetry run ruff check --fix .
 
 # Format using Ruff - requires ruff-lsp to be installed
 format-python:
-  ruff format .
+  poetry run ruff format .

--- a/common/justfile/docker-dev
+++ b/common/justfile/docker-dev
@@ -30,3 +30,11 @@ resume-docker:
 # Update the Django migration files
 update-migrations:
   python manage.py makemigrations
+
+# Lint using Ruff - requires ruff-lsp to be installed
+lint-python:
+  ruff check --fix .
+
+# Format using Ruff - requires ruff-lsp to be installed
+format-python:
+  ruff format .


### PR DESCRIPTION
+ [X] Add Ruff to extensions.json for VS Code users
+ [X] Add Ruff to justfile - @lwjohnst86 I have added lint-python and format-python in the docker-dev justfile. Is that the correct location?

Closes seedcase-project/seedcase-sprout#31 when they have been synced to the other repos

Do we want a GitHub action as well? 