### PR TITLE
ci: :construction_worker: Add community repo to be sync'ed with standard files

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -19,6 +19,7 @@ group:
       seedcase-project/seedcase-sprout
       seedcase-project/seedcase-project
       seedcase-project/seedcase-theme
+      seedcase-project/community
       seedcase-project/design
       seedcase-project/team
 
@@ -40,4 +41,5 @@ group:
     repos: |
       seedcase-project/seedcase-project
       seedcase-project/design
+      seedcase-project/community
       seedcase-project/team


### PR DESCRIPTION
## Description

These changes are done because I created the community repo and it needs to be connected.

