### PR TITLE
fix: :art: Mostly stylistic, having spaces around TODO, plus add `:`

### DIFF
--- a/.vscode/json.code-snippets
+++ b/.vscode/json.code-snippets
@@ -18,7 +18,7 @@
 		"scope": "quarto,markdown",
 		"prefix": "TODO",
 		"body": [
-			"<!--TODO ${0:Write text here}-->"
+			"<!-- TODO: ${0:Write text here} -->"
 		],
 		"description": "Insert TODO formatting"
 	}


### PR DESCRIPTION
## Description

These changes are done for mostly aesthetic reasons.
