### PR TITLE
build: :hammer: Use docker command in justfile for rendering websites with Quarto

### DIFF
--- a/common/justfile/web
+++ b/common/justfile/web
@@ -7,4 +7,4 @@ generate-puml:
 
 # Build the website using Quarto
 build-website:
-  quarto render
+  docker run --rm -v $(pwd):/site -w /site ghcr.io/quarto-dev/quarto:latest quarto render


### PR DESCRIPTION
## Description

These changes are done because this makes it easier for others to re-build websites using the latest version of Quarto. So rather than depend on the developer installing Quarto, you can render the website as long as you have Docker :grin:
