### PR TITLE
feat: :wrench: Add conventional branch and its settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -17,7 +17,8 @@
 		"quarto.quarto",
 		"streetsidesoftware.code-spell-checker",
 		"vivaxy.vscode-conventional-commits",
-		"charliermarsh.ruff"
+		"charliermarsh.ruff",
+		"pshaddel.conventional-branch"
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,11 +12,14 @@
   "editor.tabCompletion": "on",
   "editor.snippetSuggestions": "inline",
   "conventional-branch.type": [
-    "docs",
-    "feat",
-    "fix",
-    "build",
-    "chore"
-  ],
+    "build",  # Changes that affect the build system or external dependencies
+    "ci", # Changes to our CI configuration files and scripts
+    "docs", # Documentation only changes
+    "feat", # A new feature
+    "fix", # A bug fix
+    "refactor",# A code change that neither fixes a bug nor adds a feature
+    "style", # Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+    "test", # Adding missing tests or correcting existing tests
+];
   "conventional-branch.format": "{Type}/{Branch}"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,13 @@
   "autoDocstring.includeName": true,
   "autoDocstring.startOnNewLine": true,
   "editor.tabCompletion": "on",
-  "editor.snippetSuggestions": "inline"
+  "editor.snippetSuggestions": "inline",
+  "conventional-branch.type": [
+    "docs",
+    "feat",
+    "fix",
+    "build",
+    "chore"
+  ],
+  "conventional-branch.format": "{Type}/{Branch}"
 }


### PR DESCRIPTION
## Description

<!-- DO NOT LEAVE THIS SECTION BLANK -->

- This PR adds the feature of using the conventional branch VSCode extension to the recommended extensions, as well as some settings on the names to give for the branches.

## Testing

- [ ] Yes
- [x] No, not needed (give a reason below)
- [ ] No, I need help writing them
