### PR TITLE
fix: :hammer: Fix docker build recipes in justfile.

### DIFF
--- a/common/justfile/django
+++ b/common/justfile/django
@@ -5,17 +5,13 @@
 generate-puml:
   docker run --rm -v $(pwd):/puml -w /puml ghcr.io/plantuml/plantuml:latest -tpng "**/*.puml"
 
-# Start up the docker container (with build)
+# Start up the docker container
 start-docker:
-  docker compose -f docker-compose.yml up -d --build
+  docker compose up -d
 
 # Close the docker container
 stop-docker:
-  docker compose -f docker-compose.yml down
-
-# Resume running docker container (without build)
-resume-docker:
-  docker compose -f docker-compose.yml up -d
+  docker compose down
 
 # Update the Django migration files
 update-migrations:


### PR DESCRIPTION
## Description

- This PR fixes the build `justfile` for starting and stopping the Docker image. Mostly to simplify them, as well as remove the "build" one (don't think we need it).