### PR TITLE
ci: :pencil2: This should have been "json" not "quarto" after the renaming

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -7,8 +7,8 @@ group:
         dest: .editorconfig
       - source: .gitignore
         dest: .gitignore
-      - source: .vscode/quarto.code-snippets
-        dest: .vscode/quarto.code-snippets
+      - source: .vscode/json.code-snippets
+        dest: .vscode/json.code-snippets
       - source: .vscode/settings.json
         dest: .vscode/settings.json
       - source: .vscode/extensions.json


### PR DESCRIPTION
## Description

- This PR fixes the typo in the sync'ing file. It should have been "json" not "quarto" after we dealt with that previous bug.

