### PR TITLE
chore: :wrench: Use correct comment character (can't use `#`) and add `chore` as a type

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,14 +12,15 @@
   "editor.tabCompletion": "on",
   "editor.snippetSuggestions": "inline",
   "conventional-branch.type": [
-    "build",  # Changes that affect the build system or external dependencies
-    "ci", # Changes to our CI configuration files and scripts
-    "docs", # Documentation only changes
-    "feat", # A new feature
-    "fix", # A bug fix
-    "refactor",# A code change that neither fixes a bug nor adds a feature
-    "style", # Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-    "test", # Adding missing tests or correcting existing tests
-];
+    "build",  // Changes that affect the build system or external dependencies
+    "ci", // Changes to our CI configuration files and scripts
+    "docs", // Documentation only changes
+    "feat", // A new feature
+    "fix", // A bug fix
+    "refactor", // A code change that neither fixes a bug nor adds a feature
+    "style", // Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+    "test", // Adding missing tests or correcting existing tests
+    "chore", // Misc things, like renaming or deleting files
+  ],
   "conventional-branch.format": "{Type}/{Branch}"
 }


### PR DESCRIPTION
## Description

<!-- 
This template covers all PRs for Seedcase, please note that if you are
submitting a PR for changes to:

a) General documentation you should delete the sections Testing, Code
Documentation, and the first part of the Author Checklist.

b) Code you should delete the second section of the Author Checklist.

Otherwise, delete any sections that don't apply.
-->

<!-- DO NOT LEAVE THIS SECTION BLANK -->

- This PR fixes the issue with the `settings.json` file not recognizing `#` as the start of comments. 
- Also added a "chore" type for the conventional branch.

## Reviewer Focus

<!-- Any particular section the reviewer should focus on, anywhere that would be a good place to start? -->

No review is necessary, was already done in the sprout repo.
