### PR TITLE
feat: ignore "module imported but unused" error in init files

### DIFF
--- a/common/ruff.toml
+++ b/common/ruff.toml
@@ -19,3 +19,7 @@ convention = "google"
 
 [format]
 docstring-code-format = true
+
+[lint.per-file-ignores]
+# ignore "Module imported but unused" error in all init files
+"__init__.py" = ["F401"]


### PR DESCRIPTION
This includes all init files in the repo. 

## Description

<!-- 
This template covers all PRs for Seedcase, please note that if you are
submitting a PR for changes to:

a) General documentation you should delete the sections Testing, Code
Documentation, and the first part of the Author Checklist.

b) Code you should delete the second section of the Author Checklist.

Otherwise, delete any sections that don't apply.
-->

<!-- DO NOT LEAVE THIS SECTION BLANK -->

- This PR adds that Ruff ignores the F401 ("module imported but unused”) error in all `__init__.py` files in the repo. 
- Currently, we add unused imports in the init files to ease the import in other modules (@philter87 correct me, if I'm wrong), and add a `#noqa` comment after each import to get Ruff to ignore these specific lines. This PR fixes this globally, for all init files,  instead.

Current fix to get Ruff to ignore this, using the `#noqa` comment:
![Screenshot 2024-02-13 at 13 04 45](https://github.com/seedcase-project/.github/assets/40836345/c62fbecd-d5df-47e4-a8d4-06a9ea27ac9f)

** Example of how including these unused modules in the `__init__.py` files simplifies imports:
Importing "data_import" and "file_upload" in the init module in `views.__init__.py` like this ...
![Screenshot 2024-02-13 at 12 59 29](https://github.com/seedcase-project/.github/assets/40836345/c06e37ae-1c68-4589-a2ad-df613e3fe3ee)

... Enables a simple looking import of them in `urls.py` like this:
![image](https://github.com/seedcase-project/.github/assets/40836345/20464a0d-90b0-43cf-869c-a3eac3da4eeb)



**Alternative solution**
Alternatively, we should stop using the `__init__.py` files like this, and import functions individually. E.g., `from views.data_import import data_import` and `from views.file_upload import file_upload`. 
