### PR TITLE
fix: :art: remove max line length of 79 so we return to default of 88

### DIFF
--- a/common/ruff.toml
+++ b/common/ruff.toml
@@ -1,9 +1,6 @@
 # Support Python 3.10+
 target-version = "py310"
 
-# Set the maximum line length to 79.
-line-length = 79
-
 # In addition to the default formatters/linters, add these as well.
 extend-select = [
   # Add the `line-too-long` rule to the enforced rule set. 


### PR DESCRIPTION
## Description

<!-- 
This template covers all PRs for Seedcase, please note that if you are
submitting a PR for changes to:

a) General documentation you should delete the sections Testing, Code
Documentation, and the first part of the Author Checklist.

b) Code you should delete the second section of the Author Checklist.

Otherwise, delete any sections that don't apply.
-->

<!-- DO NOT LEAVE THIS SECTION BLANK -->

- This PR removes the max line length of 79, so we return to the ruff and black default of 88.
- These changes are done after talking to @philter87 and @lwjohnst86 about this. 

