### PR TITLE
build: add sqlite3-editor to recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -18,7 +18,8 @@
 		"streetsidesoftware.code-spell-checker",
 		"vivaxy.vscode-conventional-commits",
 		"charliermarsh.ruff",
-		"pshaddel.conventional-branch"
+		"pshaddel.conventional-branch",
+		"yy0931.vscode-sqlite3-editor"
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": [


### PR DESCRIPTION
## Description

<!-- 
This template covers all PRs for Seedcase, please note that if you are
submitting a PR for changes to:

a) General documentation you should delete the sections Testing, Code
Documentation, and the first part of the Author Checklist.

b) Code you should delete the second section of the Author Checklist.

Otherwise, delete any sections that don't apply.
-->

<!-- DO NOT LEAVE THIS SECTION BLANK -->

- This PR adds SQLite3 Editor to the list of recommended VS Code extensions. 
- As discussed at the demo 15 February, this is a nice extension for examining the database as well as edit the data within it (in contrast to the SQLite Viewer extension, which is readonly).
