### PR TITLE
ci: :construction_worker: setup reusable actions and fix deploy issue

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -34,10 +34,6 @@ group:
         dest: .github/workflows/deploy-pr-preview.yml
       - source: common/actions/deploy-demo.yml
         dest: .github/workflows/deploy-demo.yml
-      - source: common/actions/test.yml
-        dest: .github/workflows/test.yml
-      - source: common/actions/lint-python.yml
-        dest: .github/workflows/lint-python.yml
       
       # VSCode Settings
       - source: .vscode/google-notypes.mustache

--- a/actions/lint-python.yml
+++ b/actions/lint-python.yml
@@ -1,12 +1,7 @@
 name: Lint Python Code
 
-on: 
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+on:
+  workflow_call:
 
 jobs:
   lint:

--- a/actions/test.yml
+++ b/actions/test.yml
@@ -1,15 +1,10 @@
-name: Run tests
+name: Run Django Tests
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+  workflow_call:
 
 jobs:
-  test:
+  django-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/common/actions/deploy-demo.yml
+++ b/common/actions/deploy-demo.yml
@@ -1,28 +1,29 @@
 name: Deploy Demo App
 
-# Only trigger when pushed/merged to main and after running the tests actions.
 on:
-  workflow_run:
-    workflows: 
-      - 'Run tests'
-    types: 
-      - completed
+  push:
     branches:
       - main
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    uses: seedcase-project/.github/actions/lint-python.yml@main
+
+  django-test:
+    runs-on: ubuntu-latest
+    uses: seedcase-project/.github/actions/test.yml@main
+    needs: lint
+
   deploy:
     name: Deploy app
     runs-on: ubuntu-latest
-
-    # Only run when test workflow passes.
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    needs: django-test
 
     concurrency: deploy-group    # optional: ensure only one action runs at a time
     steps:
 
-      - name: Checkout the repository
-        uses: actions/checkout@v4
+      - uses: seedcase-project/.github/actions/test.yml@main
 
       - name: Deploy to Fly.io
         uses: superfly/flyctl-actions/setup-flyctl@master

--- a/common/actions/deploy-pr-preview.yml
+++ b/common/actions/deploy-pr-preview.yml
@@ -2,12 +2,8 @@
 name: Deploy PR Preview App
 
 on:
-  workflow_run:
-    workflows: 
-      - 'Run tests'
-    types: 
-      - completed
-    branches-ignore:
+  pull_request:
+    branches:
       - main
 
 env:
@@ -16,14 +12,18 @@ env:
   FLY_ORG: seedcase-project
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    uses: seedcase-project/.github/actions/lint-python.yml@main
+
+  django-test:
+    runs-on: ubuntu-latest
+    uses: seedcase-project/.github/actions/test.yml@main
+    needs: lint
+
   staging_app:
     runs-on: ubuntu-latest
-
-    # The `on.EVENT` (e.g. `on.pull_request`) used above usually can be combined with other EVENTS
-    # like `on.push`, `on.issues`, or `on.schedule`. But `on.workflow_run` doesn't work with other 
-    # EVENTS, like `on.pull_request`. So to make it only run on PRs, we need to use this `if` condition,
-    # so that this only runs after the tests have successfully passed and only on pull requests.
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
+    needs: django-test
 
     # Only run one deployment at a time per PR.
     concurrency:

--- a/common/actions/deploy-pr-preview.yml
+++ b/common/actions/deploy-pr-preview.yml
@@ -1,8 +1,9 @@
 # From: https://github.com/superfly/fly-pr-review-apps
 name: Deploy PR Preview App
 
-on:
-  pull_request:
+on:  
+  pull_request:  
+    types: [opened, reopened, synchronize, closed]  
     branches:
       - main
 


### PR DESCRIPTION
## Description

<!-- 
This template covers all PRs for Seedcase, please note that if you are
submitting a PR for changes to:

a) General documentation you should delete the sections Testing, Code
Documentation, and the first part of the Author Checklist.

b) Code you should delete the second section of the Author Checklist.

Otherwise, delete any sections that don't apply.
-->

<!-- DO NOT LEAVE THIS SECTION BLANK -->

- This PR hopefully fixes the bug that the deploy preview action can't get the PR number because it isn't ran within the PR (doesn't use `on.pull_request`).
- These changes hopefully fix that issue by moving out the test and lint actions and converting them into reusable actions that can be referenced directly without synching to other repos. This also fixes the actions so that they run from lint to test to deploy. It ends up being a cleaner implementation plus doesn't need to synch more files across repos.

## Related Issues

<!-- List issues the PR closes -->

Closes #85

<!-- Connect this PR to relevant issues, to help the reviewer but also for record-keeping. -->


## Testing

- [ ] Yes
- [x] No, not needed (give a reason below)
- [ ] No, I need help writing them

<!-- Please explain why the tests are not needed for this PR here -->

It's hard to test actions.

## Reviewer Focus
<!-- Please delete as appropriate: -->
This PR maybe needs a quick review?

<!-- Any particular section the reviewer should focus on, anywhere that would be a good place to start? -->


