### PR TITLE
fix: :construction_worker: Seems you can't use `runs-on` with `uses`.

### DIFF
--- a/common/actions/deploy-demo.yml
+++ b/common/actions/deploy-demo.yml
@@ -7,11 +7,9 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
     uses: seedcase-project/.github/.github/workflows/lint-python.yml@main
 
   django-test:
-    runs-on: ubuntu-latest
     uses: seedcase-project/.github/.github/workflows/test.yml@main
     needs: lint
 

--- a/common/actions/deploy-pr-preview.yml
+++ b/common/actions/deploy-pr-preview.yml
@@ -14,11 +14,9 @@ env:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
     uses: seedcase-project/.github/.github/workflows/lint-python.yml@main
 
   django-test:
-    runs-on: ubuntu-latest
     uses: seedcase-project/.github/.github/workflows/test.yml@main
     needs: lint
 


### PR DESCRIPTION
## Description

<!-- 
This template covers all PRs for Seedcase, please note that if you are
submitting a PR for changes to:

a) General documentation you should delete the sections Testing, Code
Documentation, and the first part of the Author Checklist.

b) Code you should delete the second section of the Author Checklist.

Otherwise, delete any sections that don't apply.
-->

<!-- DO NOT LEAVE THIS SECTION BLANK -->

It's difficult to test out Actions, but seems that you can't use `runs-on` when using a reusable action, because it already has a `runs-on` within it. Hopefully this fixes it...