### PR TITLE
chore: :rotating_light: Updates to Ruff config, like a deprecation notice as well as an ignoring tests and migration files

### DIFF
--- a/common/ruff.toml
+++ b/common/ruff.toml
@@ -2,6 +2,7 @@
 target-version = "py310"
 
 # In addition to the default formatters/linters, add these as well.
+[lint]
 extend-select = [
   # Add the `line-too-long` rule to the enforced rule set. 
   "E501", 

--- a/common/ruff.toml
+++ b/common/ruff.toml
@@ -11,6 +11,8 @@ extend-select = [
   # Add isort to list.
   "I"
 ]
+# Ignore Django migration files
+exclude = ["**/migrations/*.py"]
 
 [lint.pydocstyle]
 convention = "google"
@@ -21,3 +23,4 @@ docstring-code-format = true
 [lint.per-file-ignores]
 # ignore "Module imported but unused" error in all init files
 "__init__.py" = ["F401"]
+"**/tests/*" = ["D"]


### PR DESCRIPTION
## Description

<!-- 
This template covers all PRs for Seedcase, please note that if you are
submitting a PR for changes to:

a) General documentation you should delete the sections Testing, Code
Documentation, and the first part of the Author Checklist.

b) Code you should delete the second section of the Author Checklist.

Otherwise, delete any sections that don't apply.
-->

<!-- DO NOT LEAVE THIS SECTION BLANK -->

- This PR fixes the `ruff.toml` file to use the `[lint]` first-level setting since top-level settings were recently deprecated, as well as add ignores for migration files and not requiring docstrings for tests.

## Reviewer Focus
<!-- Please delete as appropriate: -->
This PR only needs a quick review.

<!-- Any particular section the reviewer should focus on, anywhere that would be a good place to start? -->


