### PR TITLE
misc: ignore migrations and persistant storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,9 @@ site
 
 # Local data files
 **/datafile/*
+# Persistent storage should not be stored in git except for the markdown files
+persistent_storage
+!persistent_storage/**/*.md
 
 # Python Django
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,5 @@ site
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
+# We'll disable migrations for now, until we have actual users
+sprout/migrations

--- a/.gitignore
+++ b/.gitignore
@@ -96,4 +96,4 @@ local_settings.py
 db.sqlite3
 db.sqlite3-journal
 # We'll disable migrations for now, until we have actual users
-sprout/migrations
+migrations


### PR DESCRIPTION
## Description

@philter87 had added this to the [PR#213: Goodbye migrations](https://github.com/seedcase-project/seedcase-sprout/pull/213), but these were overwritten in a sync. 

So, I have added it here again (I have just shortened the original comment)

EDIT: Philter has added `persistant_storage` as well.