### PR TITLE
build: ignore d100

### DIFF
--- a/common/ruff.toml
+++ b/common/ruff.toml
@@ -11,6 +11,9 @@ extend-select = [
   # Add isort to list.
   "I"
 ]
+# Ignore missing docstring at the top of files
+ignore = ["D100"]
+
 # Ignore Django migration files
 exclude = ["**/migrations/*.py"]
 


### PR DESCRIPTION
## Description

<!-- 
This template covers all PRs for Seedcase, please note that if you are
submitting a PR for changes to:

a) General documentation you should delete the sections Testing, Code
Documentation, and the first part of the Author Checklist.

b) Code you should delete the second section of the Author Checklist.

Otherwise, delete any sections that don't apply.
-->

<!-- DO NOT LEAVE THIS SECTION BLANK -->

- This PR adds that Ruff ignores D100, i.e., "missing docstring in public modules"
- These changes are done since the docstrings at the top of files (as we currently write them at least) don't really add new information. Therefore, they are kind of redundant.
