### PR TITLE
fix: add organise code imports on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,9 @@
   "editor.tabSize": 2,
   "editor.wordWrap": "off",
   "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": "always"
+  },
   "git.autofetch": false,
   "quarto.visualEditor.markdownWrap": "column",
   "quarto.visualEditor.markdownWrapColumn": 72,


### PR DESCRIPTION
## Description

To avoid having to fix organising import sorting by hand, I have added that it will happen on save 👍

I have made some simple (informal) tests locally and it seems to work as expected.
