### PR TITLE
feat: add reset-local recipe

### DIFF
--- a/common/justfile/django
+++ b/common/justfile/django
@@ -47,3 +47,9 @@ install-deps:
 # Add test data when running locally based on json files found in `fixtures/`
 add-test-data: install-deps update-migrations
   poetry run python manage.py loaddata */fixtures/*.json
+
+# Reset local Sprout (remove __pycache__ folders, db, and migrations)
+reset-local: 
+  find . -type d -name "__pycache__" -exec rm -rf {} +
+  find */migrations -type f ! -name '__init__.py' -exec rm {} \;
+  rm db.sqlite3


### PR DESCRIPTION
## Description

In this PR, I attempt to add a `just` recipe to that resets Sprout locally. This includes removing `__pycache__` folders, removing the db `db.sqlite3`, and all migrations. 

Im not too familiar with the commands I have used to achieve this, but the local testing of these seemed to work as expected.
