### PR TITLE
feat: update settings to enable UK dictionary in CSpell

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,8 +32,9 @@
   },
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
   "python.languageServer": "Pylance",
-  "files.insertFinalNewline": true, 
+  "files.insertFinalNewline": true,
   "cSpell.enableFiletypes": [
-  	"quarto"
+    "quarto"
   ],
+  "cSpell.language": "en,en-GB",
 }


### PR DESCRIPTION
## Description

<!-- 
This template covers all PRs for Seedcase, please note that if you are
submitting a PR for changes to:

a) General documentation you should delete the sections Testing, Code
Documentation, and the first part of the Author Checklist.

b) Code you should delete the second section of the Author Checklist.

Otherwise, delete any sections that don't apply.
-->

<!-- DO NOT LEAVE THIS SECTION BLANK -->

- This PR adds the UK dictionary to CSpell in the main settings on .github.
- These changes are done because the Seedcase team have decided that we are happy with both UK and US spelling in our code and documentation.

## Related Issues

<!-- List issues the PR closes -->

Closes #35 

## Testing

- [ ] Yes
- [ ] No, not needed (give a reason below)
- [x] No, I need help writing them

<!-- Please explain why the tests are not needed for this PR here -->
I'm not sure how I would go about testing this, other than checking that it accepts both UK and US spelling, which it does.

## Reviewer Focus
<!-- Please delete as appropriate: -->
This PR only needs a quick review.

<!-- Any particular section the reviewer should focus on, anywhere that would be a good place to start? -->

## Checklist

<!-- This is to help you determine if your work is ready to be reviewed, if an item is not relevant then you can mark it as done (because you have checked and found that it isn't needed) -->

For all PRs that are not general documentation

- [ ] Tests accompany or reflect changes to the code
- [ ] Tests ran and passed locally
- [ ] Ran the linter and formatter
- [ ] Build has passed locally
- [ ] Relevant documentation has been updated
