### PR TITLE
refactor: split out category keywords from post header snippet

### DIFF
--- a/.vscode/json.code-snippets
+++ b/.vscode/json.code-snippets
@@ -36,7 +36,7 @@
 	
 	"Insert YAML header for blogs": {
 		"scope": "quarto,markdown",
-		"prefix": "yaml_blog",
+		"prefix": "post_yaml",
 		"body": [
 			"---"
 			"title: \"\""
@@ -44,6 +44,7 @@
 			"author: \"\""
 			"date: last-modified"
 			"categories:"
+			"  ${0:Type 'category_keywords' to insert categories}"
 			"---"
 		],
 		"description": "Insert YAML header for Quarto blog posts."
@@ -112,55 +113,48 @@
 // The idea is that we can insert this section and then delete the words we aren't interested in
 // If words are missing then they can be added to the document, and then also added to the code snippet
 // Much the same way that words can be added to the spell-check extension.
-	"Insert title section with list of category words": {
-		"scope": "quarto,markdown",
-		"prefix": "ttl_sec_cat",
+	"Insert list of category words": {
+		"scope": "quarto,markdown,yaml",
+		"prefix": "category_keywords",
 		"body": [
-			"---"
-			"title: \"\""
-			"description: \"Our reasons for ...\""
-			"author: \"\""
-			"date: last-modified"
-			"categories:"
-			"  - api"
-			"  - backend"
-			"  - blogs"
-			"  - code snippets"
-			"  - communication"
-			"  - container"
-			"  - contributing"
-			"  - copyright"
-			"  - culture"
-			"  - database"
-			"  - development"
-			"  - documentation"
-			"  - frontend"
-			"  - github"
-			"  - implementation"
-			"  - installation"
-			"  - licensing"
-			"  - management"
-			"  - markdown"
-			"  - organization"
-			"  - programming"
-			"  - repositories"
-			"  - reviewing"
-			"  - software"
-			"  - software architecture"
-			"  - standardisation"
-			"  - structure"
-			"  - team work"
-			"  - teamworking"
-			"  - technology"
-			"  - templates"
-			"  - tools"
-			"  - vs code"
-			"  - web"
-			"  - website"
-			"  - workflow"
-			"  - writing"
-			"---"
+			"- api"
+			"- backend"
+			"- blogs"
+			"- code snippets"
+			"- communication"
+			"- container"
+			"- contributing"
+			"- copyright"
+			"- culture"
+			"- database"
+			"- development"
+			"- documentation"
+			"- frontend"
+			"- github"
+			"- implementation"
+			"- installation"
+			"- licensing"
+			"- management"
+			"- markdown"
+			"- organization"
+			"- programming"
+			"- repositories"
+			"- reviewing"
+			"- software"
+			"- software architecture"
+			"- standardisation"
+			"- structure"
+			"- team work"
+			"- teamworking"
+			"- technology"
+			"- templates"
+			"- tools"
+			"- vs code"
+			"- web"
+			"- website"
+			"- workflow"
+			"- writing"
 		],
-		"description": "Insert title with category words"
+		"description": "Insert list of category words"
 	}
 }


### PR DESCRIPTION
## Description

<!-- 
This template covers all PRs for Seedcase, please note that if you are
submitting a PR for changes to:

a) General documentation you should delete the sections Testing, Code
Documentation, and the first part of the Author Checklist.

b) Code you should delete the second section of the Author Checklist.

Otherwise, delete any sections that don't apply.
-->

<!-- DO NOT LEAVE THIS SECTION BLANK -->

- This PR moves category keywords from the post header snippet into a separate code snippet.

## Related Issues

<!-- List issues the PR closes -->

Closes #30 

## Testing

- [ ] Yes
- [x] No, not needed (give a reason below)
- [ ] No, I need help writing them

<!-- Please explain why the tests are not needed for this PR here -->
Manual testing done to make sure snippets work as intended.

## Reviewer Focus
<!-- Please delete as appropriate: -->
This PR only needs a quick review.

<!-- Any particular section the reviewer should focus on, anywhere that would be a good place to start? -->

## Checklist

<!-- This is to help you determine if your work is ready to be reviewed, if an item is not relevant then you can mark it as done (because you have checked and found that it isn't needed) -->

For all PRs that are not general documentation

- [x] Tests accompany or reflect changes to the code
- [x] Tests ran and passed locally
- [x] Ran the linter and formatter
- [x] Build has passed locally
- [x] Relevant documentation has been updated
