### PR TITLE
ci: :construction_worker: forgot to add launch.json to sync'ing between repos

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -42,6 +42,8 @@ group:
         dest: .vscode/google-notypes.mustache
       - source: .vscode/python.code-snippets
         dest: .vscode/python.code-snippets
+      - source: .vscode/launch.json
+        dest: .vscode/launch.json
       
       # Misc
       - source: common/justfile/django


### PR DESCRIPTION
## Description

Signe added the debugger for Django, and we forgot to connect the `launch.json` file to be sync'ed.
