### PR TITLE
chore: :technologist: remove `pyproject.toml` and `poetry.lock` from triggering reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,3 +9,5 @@ justfile
 .editorconfig
 .gitignore
 ruff.toml
+pyproject.toml
+poetry.lock


### PR DESCRIPTION
## Description

Now that we have the dependabot working in Sprout, we don't want everyone to be requested for review whenever a new version is bumped and a PR is created.