### PR TITLE
build: :hammer: needs to temporarily switch to docs folder to build website

### DIFF
--- a/common/justfile/django
+++ b/common/justfile/django
@@ -57,4 +57,4 @@ reset-local:
 
 # Build the documentation website using Quarto
 build-website:
-  docker run --rm -v $(pwd):/site -w /site ghcr.io/quarto-dev/quarto:latest quarto render docs
+  (cd ./docs && docker run --rm -v $(pwd):/site -w /site ghcr.io/quarto-dev/quarto:latest quarto render)


### PR DESCRIPTION
## Description

The justfile recipe for building a website in a non-root location needs to move to that folder to find the `_extensions/` theme.


## Testing

- [x] Yes
- [ ] No, not needed (give a reason below)
- [ ] No, I need help writing them

<!-- Please explain why the tests are not needed for this PR here -->

## Reviewer Focus
<!-- Please delete as appropriate: -->
This PR only needs a quick review.

<!-- Any particular section the reviewer should focus on, anywhere that would be a good place to start? -->
