### PR TITLE
ci: :green_heart: update CI and justfile to run Quarto in root of project

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -15,20 +15,11 @@ jobs:
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
-        with:
-          # To install LaTeX to build PDF book
-          tinytex: false
-          # uncomment below and fill to pin a version
-          # version: 0.9.600
 
       # add software dependencies here
-
-      # To publish to Netlify, RStudio Connect, or GitHub Pages, uncomment
-      # the appropriate block below
 
       - name: Publish to Netlify (and render)
         uses: quarto-dev/quarto-actions/publish@v2
         with:
-          path: docs
           target: netlify
           NETLIFY_AUTH_TOKEN: ${{ secrets.netlify-token }}

--- a/common/actions/deploy-docs.yml
+++ b/common/actions/deploy-docs.yml
@@ -6,6 +6,10 @@ on:
       - main
     paths:
       - docs/**
+      - _quarto.yml
+      - index.qmd
+      - _publish.yml
+      - _extensions/**
 
 jobs:
   build-deploy-docs:

--- a/common/justfile/django
+++ b/common/justfile/django
@@ -57,4 +57,4 @@ reset-local:
 
 # Build the documentation website using Quarto
 build-website:
-  (cd ./docs && docker run --rm -v $(pwd):/site -w /site ghcr.io/quarto-dev/quarto:latest quarto render)
+  docker run --rm -v $(pwd):/site -w /site ghcr.io/quarto-dev/quarto:latest quarto render


### PR DESCRIPTION
## Description

Quarto and the Quarto action assume the Git repo is the root of the Quarto project, but we were building the Sprout website where the website root was docs folder. So I was having to fight the default assumption. I've revised everything so we just keep it simple as assume the default is the Git root folder is also the website root folder.