### PR TITLE
ci: :construction_worker: don't build and deploy Django when website/doc files change

### DIFF
--- a/common/actions/deploy-demo.yml
+++ b/common/actions/deploy-demo.yml
@@ -5,13 +5,20 @@ on:
     branches:
       - main
     paths-ignore:
-      - "docs/**"
+      # Config files
       - ".github/**"
       - ".vscode/**"
+      - ".gitignore"
+      # Documentation
+      - "docs/**"
       - "*.md"
       - "*.qmd"
-      - ".gitignore"
       - "justfile"
+      # Website files
+      - _quarto.yml
+      - index.qmd
+      - _publish.yml
+      - _extensions/**
 
 jobs:
   lint:


### PR DESCRIPTION
## Description

The Django project doesn't need to be deployed when documentation or website setting files are changed.