### PR TITLE
docs: :technologist: create two PR templates for doc and software

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,63 +1,16 @@
 ## Description
 
-<!-- 
-This template covers all PRs for Seedcase, please note that if you are
-submitting a PR for changes to:
+These changes are done for PURPOSE, because REASON.
 
-a) General documentation you should delete the sections Testing, Code
-Documentation, and the first part of the Author Checklist.
-
-b) Code you should delete the second section of the Author Checklist.
-
-Otherwise, delete any sections that don't apply.
--->
-
-<!-- DO NOT LEAVE THIS SECTION BLANK -->
-
-- This PR {removes/adds/fixes/replaces} the {feature/bug/issue/documentation/tests}.
-- These changes are done because of ... {reasons for change/why you're doing it}.
-
-## Related Issues
-
-<!-- List issues the PR closes -->
-
-Closes #...
-
-<!-- Connect this PR to relevant issues, to help the reviewer but also for record-keeping. -->
-
-See also Issues #...
-
-## Testing
-
-- [ ] Yes
-- [ ] No, not needed (give a reason below)
-- [ ] No, I need help writing them
-
-<!-- Please explain why the tests are not needed for this PR here -->
+Closes #
 
 ## Reviewer Focus
-<!-- Please delete as appropriate: -->
-This PR only needs a quick review.
-This PR requires an in-depth review.
 
-<!-- Any particular section the reviewer should focus on, anywhere that would be a good place to start? -->
+<!-- Please delete as appropriate: -->
+This PR needs a quick/in-depth review. Focus on CHANGES.
 
 ## Checklist
 
-<!-- This is to help you determine if your work is ready to be reviewed, if an item is not relevant then you can mark it as done (because you have checked and found that it isn't needed) -->
-
-For all PRs that are not general documentation
-
-- [ ] Tests accompany or reflect changes to the code
-- [ ] Tests ran and passed locally
-- [ ] Ran the linter and formatter
-- [ ] Build has passed locally
-- [ ] Relevant documentation has been updated
-
-For general documentation:
-
-- [ ] Spell-check
-    - [ ] US
-    - [ ] UK
-- [ ] Did the page(s) preview correctly on your machine without breaking
-- [ ] New category words (keywords) (if any) added to the code snippet file
+- [ ] Ran spell-check
+- [ ] Formatted Markdown
+- [ ] Rendered website locally

--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -38,7 +38,7 @@ group:
         dest: .github/workflows/deploy-demo.yml
       - source: common/actions/deploy-docs.yml
         dest: .github/workflows/deploy-docs.yml
-      
+
       # VSCode Settings
       - source: .vscode/google-notypes.mustache
         dest: .vscode/google-notypes.mustache
@@ -54,6 +54,8 @@ group:
         dest: ruff.toml
       - source: common/LICENSE.md
         dest: LICENSE.md
+      - source: common/templates/software-pull-request.md
+        dest: .github/pull_request_template.md
     repos: |
       seedcase-project/seedcase-sprout
 

--- a/common/templates/software-pull-request.md
+++ b/common/templates/software-pull-request.md
@@ -1,0 +1,18 @@
+## Description
+
+These changes are done for PURPOSE, because REASON.
+
+Closes #
+
+## Reviewer Focus
+
+<!-- Select quick/in-depth as necessary -->
+This PR needs a quick/in-depth review. Focus on CHANGES.
+
+## Checklist
+
+- [ ] Added or updated tests
+- [ ] Tests passed locally
+- [ ] Linted and formatted code
+- [ ] Build passed locally
+- [ ] Updated documentation 


### PR DESCRIPTION
## Description

I simplified the template and split it into two, one for documentation and another for software. The software one syncs to the software repos. 

Only needs a quick review.

Closes #62