### PR TITLE
ci: :construction_worker: step to (hopefully) delete the GitHub environment after closing PR

### DIFF
--- a/common/actions/deploy-pr-preview.yml
+++ b/common/actions/deploy-pr-preview.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Deploy preview of PR
         id: deploy
-        uses: superfly/fly-pr-review-apps@1.2.0
+        uses: superfly/fly-pr-review-apps@1.2.1
         with:
           name: ${{ github.event.repository.name }}-pr-${{ github.event.number }}
 

--- a/common/actions/deploy-pr-preview.yml
+++ b/common/actions/deploy-pr-preview.yml
@@ -35,7 +35,7 @@ jobs:
     uses: seedcase-project/.github/.github/workflows/test.yml@main
     needs: lint
 
-  staging_app:
+  staging-app:
     runs-on: ubuntu-latest
     needs: django-test
 
@@ -60,9 +60,12 @@ jobs:
 
       # This removes left over items in GitHub from the building and deploying.
       - name: Clean up GitHub environment
-        uses: strumwolf/delete-deployment-environment@v3
+        run: |
+          gh api \
+            --method DELETE \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/seedcase-project/${{ github.event.repository.name }}/environments/pr-${{ github.event.number }} 
         if: ${{ github.event.action == 'closed' }}
-        with:
-          # ⚠️ The provided token needs permission for admin write:org
-          token: ${{ secrets.DELETE_ENV_TOKEN }}
-          environment: pr-${{ github.event.number }}
+        env:
+          GH_TOKEN: ${{ secrets.DELETE_ENV_TOKEN }}

--- a/common/actions/deploy-pr-preview.yml
+++ b/common/actions/deploy-pr-preview.yml
@@ -7,14 +7,20 @@ on:
     branches:
       - main
     paths-ignore:
-      - "docs/**"
+      # Config files
       - ".github/**"
       - ".vscode/**"
+      - ".gitignore"
+      # Documentation
+      - "docs/**"
       - "*.md"
       - "*.qmd"
-      - ".gitignore"
       - "justfile"
-
+      # Website files
+      - _quarto.yml
+      - index.qmd
+      - _publish.yml
+      - _extensions/**
 
 env:
   FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION

## Description

Hopefully a fix to the workflow so that when a PR closes/is merged in Sprout, the GitHub deployment environment is also deleted. Since right now, I have to manually delete them, which is a bit of a small annoyance.

Only needs a small review since it might not work the first time :P Workflows are tricky to test...

## Related Issues

Closes seedcase-project/seedcase-sprout#260

<!-- Connect this PR to relevant issues, to help the reviewer but also for record-keeping. -->
