### PR TITLE
ci: :construction_worker: forgot to put assignee for this workflow as well

### DIFF
--- a/common/actions/dependabot.yml
+++ b/common/actions/dependabot.yml
@@ -8,3 +8,6 @@ updates:
     commit-message:
       prefix: build
       include: scope
+    assignees:
+      - "lwjohnst86"
+


### PR DESCRIPTION
## Description

These changes are done to add assignee to the dependabot, because I forgot to include it in this file, I only put it in the other one.

## Reviewer Focus

<!-- Please delete as appropriate: -->
This PR needs a quick review. 