### PR TITLE
chore: :hammer: fix path to pytest to link to local poetry venv

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -38,5 +38,5 @@
   ],
   "cSpell.language": "en,en-GB",
   "python.testing.pytestEnabled": true,
-  "python.testing.pytestPath": "poetry run pytest",
+  "python.testing.pytestPath": "${workspaceFolder}/.venv/bin/pytest",
 }


### PR DESCRIPTION
## Description

These changes are done to the VSCode settings, because it needs a path and I put the poetry command.
