### PR TITLE
ci: :construction_worker: move synching of website PR template to only website repos

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -13,8 +13,6 @@ group:
         dest: .vscode/settings.json
       - source: .vscode/extensions.json
         dest: .vscode/extensions.json
-      - source: .github/pull_request_template.md
-        dest: .github/pull_request_template.md
       - source: .github/workflows/add-to-project.yml
         dest: .github/workflows/add-to-project.yml
     repos: |
@@ -61,6 +59,8 @@ group:
 
   # Website repositories
   - files:
+      - source: .github/pull_request_template.md
+        dest: .github/pull_request_template.md
       - source: common/justfile/web
         dest: justfile
       - source: common/devcontainers/web.json


### PR DESCRIPTION
## Description

I forgot to move this down to the website section. The PR template in `.github` shouldn't synching to all repos, only to the website repos.