### PR TITLE
fix: :adhesive_bandage: Update docstring template

### DIFF
--- a/.vscode/google-notypes.mustache
+++ b/.vscode/google-notypes.mustache
@@ -1,36 +1,36 @@
-{{! Copied from https://github.com/NilsJPWerner/autoDocstring/blob/master/src/docstring/templates/google-notypes.mustache }}
+{{! Copied from https://github.com/NilsJPWerner/autoDocstring/blob/master/src/docstring/templates/google-notypes.mustache with some edits }}
 {{! Google Docstring Template without Types for Args, Returns or Yields }}
-{{summaryPlaceholder}}
+{{summaryPlaceholder}}.
 
 {{extendedSummaryPlaceholder}}
 {{#parametersExist}}
 
 Args:
 {{#args}}
-    {{var}}: {{descriptionPlaceholder}}
+    {{var}}: {{descriptionPlaceholder}}.
 {{/args}}
 {{#kwargs}}
     {{var}}: {{descriptionPlaceholder}}. Defaults to {{&default}}.
 {{/kwargs}}
 {{/parametersExist}}
-{{#exceptionsExist}}
-
-Raises:
-{{#exceptions}}
-    {{type}}: {{descriptionPlaceholder}}
-{{/exceptions}}
-{{/exceptionsExist}}
 {{#returnsExist}}
 
 Returns:
 {{#returns}}
-    {{descriptionPlaceholder}}
+    {{descriptionPlaceholder}}.
 {{/returns}}
 {{/returnsExist}}
+{{#exceptionsExist}}
+
+Raises:
+{{#exceptions}}
+    {{type}}: {{descriptionPlaceholder}}.
+{{/exceptions}}
+{{/exceptionsExist}}
 {{#yieldsExist}}
 
 Yields:
 {{#yields}}
-    {{descriptionPlaceholder}}
+    {{descriptionPlaceholder}}.
 {{/yields}}
 {{/yieldsExist}}


### PR DESCRIPTION
move Raises section below Returns and add `.` after placeholders

Following the Google style guide examples


## Description

These changes are done for PURPOSE, because REASON.

Closes #

## Reviewer Focus

<!-- Please delete as appropriate: -->
This PR needs a quick review. Focus on CHANGES.

