### PR TITLE
fix: change tabSize to 4

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "files.autoSave": "onFocusChange",
-  "editor.tabSize": 2,
+  "editor.tabSize": 4,
   "editor.wordWrap": "off",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {


### PR DESCRIPTION
## Description

Since that's the standard indention in Python. Right? :)
I'm not sure why we've set it to 2?

Closes #

## Reviewer Focus

<!-- Please delete as appropriate: -->
This PR needs a quick review. Focus on CHANGES.

## Checklist

N/A