### PR TITLE
ci: :construction_worker: add reusable workflow to generate SVG from puml files

### DIFF
--- a/.github/workflows/puml-to-svg.yml
+++ b/.github/workflows/puml-to-svg.yml
@@ -1,0 +1,24 @@
+name: Generate SVG from PlantUML
+
+on:
+  workflow_call:
+    secrets:
+      github-token:
+        required: true
+
+jobs:
+  generate-plantuml:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+
+    - name: plantuml
+      id: plantuml
+      uses: grassedge/generate-plantuml-action@v1.5
+      with:
+        message: "chore: :bento: (re-)generate `.svg` from `.puml` files"
+      env:
+        GITHUB_TOKEN: ${{ secrets.github-token }}


### PR DESCRIPTION
## Description

It is very annoying to have to update the svg files. So this adds a reusable workflow to solve that problem.

Closes #179

## Reviewer Focus

<!-- Please delete as appropriate: -->
This PR needs a quick review. Focus on the Git message used when this runs.
