### PR TITLE
ci: :construction_worker: setup Python venv so Quarto finds it correctly

### DIFF
--- a/.github/workflows/deploy-docs-with-python.yml
+++ b/.github/workflows/deploy-docs-with-python.yml
@@ -25,10 +25,15 @@ jobs:
       - name: Install dependencies with Poetry
         run: poetry install --no-interaction
 
+      - name: Activate venv for Quarto
+        run: |
+          source .venv/bin/activate/
+          export QUARTO_PYTHON=.venv/bin/python3
+
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
 
-      # add software dependencies here
+      # add other software dependencies here
 
       - name: Publish to Netlify (and render)
         uses: quarto-dev/quarto-actions/publish@v2


### PR DESCRIPTION
## Description

This PR will (I hope) fix the website build error happening because Quarto can't find the Poetry venv.

Closes seedcase-project/template-python-project#14

No review necessary.