### PR TITLE
ci: :construction_worker: build function reference docs

### DIFF
--- a/.github/workflows/deploy-docs-with-python.yml
+++ b/.github/workflows/deploy-docs-with-python.yml
@@ -29,7 +29,8 @@ jobs:
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
 
-      # add other software dependencies here
+      - name: Build function reference docs
+        run: python -m quartodoc build
 
       - name: Publish to Netlify (and render)
         uses: quarto-dev/quarto-actions/publish@v2


### PR DESCRIPTION

## Description

This makes the quartodocs get auto-built. I don't know if it works, will have to test it when the other PR has been merged.

Closes #190

<!-- Please delete as appropriate: -->
The change is very small, so doesn't need a review.

