### PR TITLE
ci: :fire: remove django related steps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,11 +22,5 @@ jobs:
       - name: Install dependencies with Poetry
         run: poetry install --no-interaction --no-root
 
-      - name: Create migration files if missing (remove when migrations are added to git)
-        run: poetry run python manage.py makemigrations
-
-      - name: Add database migrations to test database
-        run: poetry run python manage.py migrate
-
       - name: Run unit tests
         run: poetry run pytest


### PR DESCRIPTION
## Description

This PR removes django related steps from our test workflow, since: 
1) we don't develop in Django currently
2) it started failing in seedcase-project/seedcase-sprout#844 after I renamed the `sprout` folder

Related to seedcase-project/seedcase-sprout#845

<!-- Please delete as appropriate: -->
This PR needs a quick review.
