### PR TITLE
docs: :pen: remove django from test workflow name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Run Django Tests
+name: Run Tests
 
 on:
   workflow_call:


### PR DESCRIPTION
## Description

This PR removes "django" from the name of the workflow, since we don't use Django anymore.

<!-- Please delete as appropriate: -->
This PR needs a quick review.
