### PR TITLE
ci: :construction_worker: needs to install the package itself too

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
           cache: 'poetry'
 
       - name: Install dependencies with Poetry
-        run: poetry install --no-interaction --no-root
+        run: poetry install --no-interaction
 
       - name: Run unit tests
         run: poetry run pytest


### PR DESCRIPTION
## Description

The failing tests after removing Django are also caused by using `--no-root`. This option was used becuase the Django project didn't like it, but a Python package project needs it.

<!-- Please delete as appropriate: -->
This PR doesn't need a review.
