### PR TITLE
ci: :bug: Quarto needs to find/be in the venv

### DIFF
--- a/.github/workflows/reusable-build-docs-with-python.yml
+++ b/.github/workflows/reusable-build-docs-with-python.yml
@@ -30,7 +30,9 @@ jobs:
           python-version-file: "pyproject.toml"
 
       - name: Install the project and it's dependencies
-        run: uv sync --all-extras --dev
+        run: |
+            uv sync --all-extras --dev
+            source .venv/bin/activate
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2


### PR DESCRIPTION
## Description

Quarto has to be in the activated venv in order for things to build (I think).