### PR TITLE
ci: :construction_worker: add gh-release step

### DIFF
--- a/.github/workflows/reusable-update-python-project-version.yml
+++ b/.github/workflows/reusable-update-python-project-version.yml
@@ -48,3 +48,9 @@ jobs:
           github_token: ${{ steps.app-token.outputs.token }}
           changelog: true
 
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          # env variable containing the new version, created by the Commitizen action
+          tag_name : ${{ env.REVISION }}


### PR DESCRIPTION
## Description

This PR adds a GitHub release step to the version workflow. This *should* utilise the automatically generated release notes that GitHub can create. They can be customised by adding a `release.yml`, but lets start with this and see if it works as we expect it to 🤞 

Closes seedcase-project/seedcase-sprout#1321

<!-- Please delete as appropriate: -->
This PR needs an in-depth review.
