### PR TITLE
ci: :construction_worker: use GitHub App to create token for adding to board

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -18,6 +18,7 @@ jobs:
   add-to-project:
     uses: seedcase-project/.github/.github/workflows/reusable-add-to-project.yml@main
     with:
+      app-id: ${{ vars.ADD_TO_BOARD_APP_ID }}
       board-number: 18
     secrets:
       add-to-board-token: ${{ secrets.ADD_TO_BOARD }}

--- a/.github/workflows/reusable-add-to-project.yml
+++ b/.github/workflows/reusable-add-to-project.yml
@@ -6,6 +6,9 @@ on:
       board-number:
         required: true
         type: number
+      app-id:
+        type: "string"
+        required: true
     secrets:
       add-to-board-token:
         required: true
@@ -17,11 +20,17 @@ jobs:
     name: Add to project
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ inputs.app-id }}
+          private-key: ${{ secrets.add-to-board-token }}
+
       - name: Add issue or PR to project board
         uses: actions/add-to-project@v1.0.2
-        with: 
+        with:
           project-url: https://github.com/orgs/${{ github.repository_owner }}/projects/${{ inputs.board-number }}
-          github-token: ${{ secrets.add-to-board-token }}
+          github-token: ${{ steps.app-token.outputs.token }}
 
       - name: Assign PR to creator
         if: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
## Description

To improve security and to limit my admin burden of re-creating tokens.

<!-- Please delete as appropriate: -->
Doesn't need a review.
