### PR TITLE
ci: :technologist: add `just check-unused` to resuable build workflow

### DIFF
--- a/.github/workflows/reusable-build-python.yml
+++ b/.github/workflows/reusable-build-python.yml
@@ -57,4 +57,7 @@ jobs:
       - name: Run spell checker
         run: just check-spelling
 
+      - name: Run unused code checker
+        run: just check-unused
+
 

--- a/.github/workflows/reusable-build-python.yml
+++ b/.github/workflows/reusable-build-python.yml
@@ -59,5 +59,3 @@ jobs:
 
       - name: Run unused code checker
         run: just check-unused
-
-


### PR DESCRIPTION
## Description

This PR adds the `just check-unused` recipe to the reusable build workflow. 

As noted here: https://github.com/seedcase-project/seedcase-sprout/pull/1330#pullrequestreview-2839471750

<!-- Please delete as appropriate: -->
This PR needs a quick/an in-depth review.
