### PR TITLE
ci: :construction_worker: uv GitHub action's defaults mean these aren't needed anymore

### DIFF
--- a/.github/workflows/reusable-build-python.yml
+++ b/.github/workflows/reusable-build-python.yml
@@ -12,14 +12,6 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
-        with:
-          # Install a specific version of uv.
-          # uv recommends to set the version for best practice.
-          version: "6.0.1"
-          # To have a faster CI time, enable cache between runs.
-          enable-cache: true
-          # Reset the cache if the lock file changes.
-          cache-dependency-glob: "uv.lock"
 
       - name: Install justfile
         run: sudo apt-get install -y just


### PR DESCRIPTION
## Description

The uv setup action has been improved a lot. These `with:` options aren't needed anymore.

No review needed.
