### PR TITLE
ci: :bug: new bug claiming not to find repo, so being explicit here

### DIFF
--- a/.github/workflows/reusable-add-to-project.yml
+++ b/.github/workflows/reusable-add-to-project.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Assign PR to creator
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          gh pr edit $PR --add-assignee $AUTHOR
+          gh pr edit $PR --add-assignee $AUTHOR --repo ${{ github.repository }}
         env:
           AUTHOR: ${{ github.event.pull_request.user.login }}
           PR: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
# Description

Not sure what happened, but `gh pr edit` now errors (sometimes randomly it doesn't). So this forces it to edit the specific repository.

No review is needed.