### PR TITLE
ci: :green_heart: set default `environment` as `pypi` in release workflow

### DIFF
--- a/.github/workflows/reusable-release-package.yml
+++ b/.github/workflows/reusable-release-package.yml
@@ -12,6 +12,11 @@ on:
         type: "boolean"
         required: false
         default: false
+      environment:
+        description: "The environment to deploy to."
+        type: string
+        required: false
+        default: pypi
     secrets:
       # Needs read and write contents permission to push to main.
       update-version-gh-token:
@@ -19,9 +24,10 @@ on:
 
 jobs:
   release:
+    name: "Update project's version and changelog, then release to PyPI"
     if: "!startsWith(github.event.head_commit.message, 'build(version): ')"
     runs-on: ubuntu-latest
-    name: "Update project's version and changelog, then release to PyPI"
+    environment: ${{ inputs.environment }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1


### PR DESCRIPTION
# Description

Adds `pypi` as the default `environment` as passes the `environment` to the release job.

This PR needs no review. I'll merge it in to see if this fixes the issue of not being able to publish to `pypi` at the moment 🤞 
