### PR TITLE
ci: :recycle: allow use of gh CLI in Quarto website build

### DIFF
--- a/.github/workflows/reusable-build-docs-with-python.yml
+++ b/.github/workflows/reusable-build-docs-with-python.yml
@@ -5,6 +5,8 @@ on:
     secrets:
       netlify-token:
         required: true
+      github-token:
+        required: true
 
 jobs:
   build-website:
@@ -55,3 +57,5 @@ jobs:
         with:
           target: netlify
           NETLIFY_AUTH_TOKEN: ${{ secrets.netlify-token }}
+        env:
+          GH_TOKEN: ${{ secrets.github-token }}


### PR DESCRIPTION
# Description

The gh CLI needs the `GH_TOKEN` at the step it is used in. 

No review needed.