### PR TITLE
ci: :memo: workflow only releases to GitHub, not PyPI

### DIFF
--- a/.github/workflows/reusable-release-package.yml
+++ b/.github/workflows/reusable-release-package.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   release:
-    name: "Update project's version and changelog, then release to PyPI"
+    name: "Update project's version and changelog, then make GitHub release"
     if: "!startsWith(github.event.head_commit.message, 'build(version): ')"
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Description

Fix the name of the job, it only releases to GitHub.

No review needed.