### PR TITLE
fix: :construction_worker: add `has_released` output for next job to use

### DIFF
--- a/.github/workflows/reusable-release-package.yml
+++ b/.github/workflows/reusable-release-package.yml
@@ -86,4 +86,3 @@ jobs:
       - id: set-release-env
         name: Set release variable
         run: echo "has_released=true" >> "$GITHUB_OUTPUT"
-


### PR DESCRIPTION
# Description

The publishing to GitHub job needs an if condition to run or not. So this adds that output to tell the job to run.

No review needed.