### PR TITLE
fix: :bug: netlify token can't be required anymore

### DIFF
--- a/.github/workflows/reusable-build-docs.yml
+++ b/.github/workflows/reusable-build-docs.yml
@@ -10,7 +10,7 @@ on:
         default: 'netlify'
     secrets:
       netlify-token:
-        required: true
+        required: false
       github-token:
         # Needs permissions: contents: write, pages: write
         required: false


### PR DESCRIPTION
# Description

The `netlify-token` can't be required if using `hosting-provider: 'gh-pages'`

No review is needed.