### PR TITLE
feat: :construction_worker: `concurrency` to cancel previous running workflows

### DIFF
--- a/.github/workflows/reusable-build-docs-with-python.yml
+++ b/.github/workflows/reusable-build-docs-with-python.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   build-website:
     runs-on: ubuntu-latest
+    concurrency:
+      group: build-website-python-group
+      cancel-in-progress: true
     env:
         QUARTO_PYTHON: ".venv/bin/python3"
     steps:

--- a/.github/workflows/reusable-build-docs.yml
+++ b/.github/workflows/reusable-build-docs.yml
@@ -18,6 +18,9 @@ on:
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
+    concurrency:
+      group: build-website-group
+      cancel-in-progress: true
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0

--- a/.github/workflows/reusable-release-project.yml
+++ b/.github/workflows/reusable-release-project.yml
@@ -25,6 +25,9 @@ jobs:
     name: "Update project's version and changelog, then make GitHub release"
     if: "!startsWith(github.event.head_commit.message, 'build(version): ')"
     runs-on: ubuntu-latest
+    concurrency:
+      group: release-project-group
+      cancel-in-progress: true
     outputs:
       previous_version: ${{ steps.version-var.outputs.previous_version }}
       current_version: ${{ steps.version-var.outputs.current_version }}


### PR DESCRIPTION
# Description

Workflows like releasing and building the website should stop if another, newer workflow is started. This prevents errors from running e.g. several release workflows in a row (which may make the same tag). Building the website should use the latest commit and cancel previous ones.

I don't actually know if this will work, or if it needs to be in the calling workflow (not here).

Closes #275, closes #302

Needs a quick review.