### PR TITLE
refactor: :truck: rename to `check-python`, not `build`

### DIFF
--- a/.github/workflows/reusable-check-python.yml
+++ b/.github/workflows/reusable-check-python.yml
@@ -1,10 +1,10 @@
-name: Check and build package
+name: Check package
 
 on:
   workflow_call:
 
 jobs:
-  build-python:
+  check-python:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)


### PR DESCRIPTION
# Description

This workflow doesn't build, only checks.
 
Closes #248

This PR needs a quick review.
