### PR TITLE
feat: :construction_worker: allow build Python docs to deploy to gh-pages

### DIFF
--- a/.github/workflows/reusable-build-docs-with-python.yml
+++ b/.github/workflows/reusable-build-docs-with-python.yml
@@ -2,11 +2,18 @@ name: Build website
 
 on:
   workflow_call:
+    inputs:
+      hosting-provider:
+        description: "Hosting provider to use for publishing the website: netlify or gh-pages. If 'gh-pages', also need to set permissions."
+        required: false
+        type: string
+        default: 'netlify'
     secrets:
       netlify-token:
-        required: true
+        required: false
       github-token:
-        required: true
+        # Needs permissions: contents: write, pages: write
+        required: false
 
 jobs:
   build-website:
@@ -56,9 +63,17 @@ jobs:
         run: uv run quartodoc build
 
       - name: Publish to Netlify (and render)
+        if: ${{ inputs.hosting-provider == 'netlify' }}
         uses: quarto-dev/quarto-actions/publish@9e48da27e184aa238fcb49f5db75469626d43adb # v2.1.9
         with:
           target: netlify
           NETLIFY_AUTH_TOKEN: ${{ secrets.netlify-token }}
+
+      # NOTE: If Publishing to GitHub Pages, set the permissions correctly (see above).
+      - name: Publish to GitHub Pages (and render)
+        if: ${{ inputs.hosting-provider == 'gh-pages' }}
+        uses: quarto-dev/quarto-actions/publish@9e48da27e184aa238fcb49f5db75469626d43adb # v2.1.9
+        with:
+          target: gh-pages
         env:
-          GH_TOKEN: ${{ secrets.github-token }}
+          GITHUB_TOKEN: ${{ secrets.github-token }}


### PR DESCRIPTION
# Description

This partly fixes that we don't need to require GITHUB_TOKEN, but also adds the ability to deploy to gh-pages.

This PR needs a quick review.
