### PR TITLE
fix: :bug: only create GitHub release if version is new

### DIFF
--- a/.github/workflows/reusable-release-project.yml
+++ b/.github/workflows/reusable-release-project.yml
@@ -64,10 +64,11 @@ jobs:
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        if: ${{ env.PREVIOUS_REVISION != env.REVISION }}
         with:
           generate_release_notes: true
           # env variable containing the new version, created by the Commitizen action
-          tag_name : ${{ env.REVISION }}
+          tag_name: ${{ env.REVISION }}
 
       # Need to output this to tell the next job that a release was made.
       - id: version-var


### PR DESCRIPTION
# Description

The create GitHub release step was always running and has been duplicating the news items inside each release. This prevents that from happening by only running it if there is an actual new release.

No review needed.