### PR TITLE
fix: :bug: prevent existing GitHub release from being overwritten

### DIFF
--- a/.github/workflows/reusable-release-project.yml
+++ b/.github/workflows/reusable-release-project.yml
@@ -69,6 +69,9 @@ jobs:
           generate_release_notes: true
           # env variable containing the new version, created by the Commitizen action
           tag_name: ${{ env.REVISION }}
+          # To help with preventing random updates to existing releases.
+          overwrite_files: false
+          append_body: false
 
       # Need to output this to tell the next job that a release was made.
       - id: version-var


### PR DESCRIPTION
# Description

There's been an issue that the release to GitHub step randomly will append new content or just doesn't add anything. This adds some basic checks to make sure it doesn't do that as much, or at least warn us when it does happen (hopefully. I don't understand what's going on or why).

No review needed.