### PR TITLE
fix: 🐛 make sure that sourced paths are available to subsequent build steps

### DIFF
--- a/.github/workflows/reusable-build-docs-with-python.yml
+++ b/.github/workflows/reusable-build-docs-with-python.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install the project and it's dependencies
         run: |
             uv sync --all-extras --dev
-            source .venv/bin/activate
+            echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@8a96df13519ee81fd526f2dfca5962811136661b # v2.2.0


### PR DESCRIPTION
# Description

For https://github.com/seedcase-project/seedcase-soil/issues/43, I think the main issue is with the website build recipe, rather than the recent changes for soil. I believe that  `source` will only put executables on path for the current shell, but each github action step runs in its own subshell. To persist executables across subshells, we would need to [add them to path as per the docs](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#adding-a-system-path). This should allow for `format_output_for_docs()` to find the seedcase executable when it is run in a later github action step.

Closes https://github.com/seedcase-project/seedcase-soil/issues/43

This PR needs an in-depth review.

---

Note that I'm not 100% sure this is the fix because I'm unsure how to test it as I don't think I can trigger the Netlify build. Locally, you can reproduce by explicitly using a minimal path without `seedcase-flower`:

```sh
QUARTO="$(command -v quarto)"
env \
  QUARTO_PYTHON="$PWD/.venv/bin/python3" \
  PATH="/usr/bin:/bin" \
  "$QUARTO" render docs/guide/cli.qmd --execute
```

And "fix it" by instead running the following:

```sh
QUARTO="$(command -v quarto)"
env \
  QUARTO_PYTHON="$PWD/.venv/bin/python3" \
  PATH="$PWD/.venv/bin:/usr/bin:/bin" \
  "$QUARTO" render docs/guide/cli.qmd --execute
```

I moved my earlier general comment to https://github.com/seedcase-project/.github/issues/467